### PR TITLE
python script to build ephemeral data docs site without side effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # IDEs
 .idea
 .vscode
+
+# OS junk
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ Run these commands from the repo root.
 
 To see a checkpoint pass run `great_expectations checkpoint run passing_checkpoint`
 To see a checkpoint fail run `great_expectations checkpoint run failing_checkpoint`
+
+## MVP Action Limitations
+
+- If a **cloud-based** `ValidationStore` is in use we may need to disable it so that the built docs focus only on what is being validated in the Action without other side effects.

--- a/build_gh_action_site.py
+++ b/build_gh_action_site.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""
+Create a new ephemeral site store and build docs for it.
+
+Usage: `./build_gh_action_site.py`
+
+When DataContext.build_data_docs() is called, there are side effects that may
+include external cloud storage. Here we are running in a GitHub Action, so we
+create a temporary site store for use only within this action. When docs are
+built we only build this temporary site.
+
+# TODO it is not yet clear if this will surprise users. If users want their
+# TODO  cloud sites updated we could parameterize this behavior in the future.
+"""
+import os
+import uuid
+
+import great_expectations as ge
+
+
+def build_site_name() -> str:
+    short_guid = str(uuid.uuid4())[0:7]
+    return f"gh_action_site_{short_guid}"
+
+
+def build_site_config(site_name) -> dict:
+    return {
+        "class_name": "SiteBuilder",
+        "store_backend": {
+            "class_name": "TupleFilesystemStoreBackend",
+            "base_directory": f"{site_name}/",
+        },
+        "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
+    }
+
+
+def main():
+    print("Loading project")
+    context = ge.DataContext("great_expectations")
+    action_site_name = build_site_name()
+    gh_site_dir = os.path.abspath(os.path.join(os.path.curdir, action_site_name))
+    context_config = context.get_config()
+    context_config["data_docs_sites"][action_site_name] = build_site_config(
+        action_site_name
+    )
+    # Note we mangle the in memory DataContext and do not persist this config
+    context._project_config = context_config
+
+    print(f"Building docs for site: {action_site_name}")
+
+    # Build only the GitHub Actions temporary site
+    context.build_data_docs(site_names=[action_site_name])
+    print(f"Site built in directory: {gh_site_dir}")
+    # For local debugging, this is handy to verify docs built
+    context.open_data_docs(site_name=action_site_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_gh_action_site.py
+++ b/build_gh_action_site.py
@@ -60,7 +60,8 @@ def main():
     context.build_data_docs(site_names=[action_site_name])
     print(f"Site built in directory: {gh_site_dir}")
     # For local debugging, this is handy to verify docs built
-    context.open_data_docs(site_name=action_site_name)
+    if os.getenv('DEBUG_OPEN_DOCS'):
+        context.open_data_docs(site_name=action_site_name)
 
 
 if __name__ == "__main__":

--- a/build_gh_action_site.py
+++ b/build_gh_action_site.py
@@ -57,7 +57,7 @@ def main():
         print("WARNING an external validation store exists and was likely polluted.")
 
     # Build only the GitHub Actions temporary site
-    # context.build_data_docs(site_names=[action_site_name])
+    context.build_data_docs(site_names=[action_site_name])
     print(f"Site built in directory: {gh_site_dir}")
     # For local debugging, this is handy to verify docs built
     context.open_data_docs(site_name=action_site_name)

--- a/build_gh_action_site.py
+++ b/build_gh_action_site.py
@@ -59,6 +59,7 @@ def main():
     # Build only the GitHub Actions temporary site
     context.build_data_docs(site_names=[action_site_name])
     print(f"Site built in directory: {gh_site_dir}")
+    print(f'::set-output name=action_docs_location::{gh_site_dir}')
     # For local debugging, this is handy to verify docs built
     if os.getenv('DEBUG_OPEN_DOCS'):
         context.open_data_docs(site_name=action_site_name)

--- a/build_gh_action_site.py
+++ b/build_gh_action_site.py
@@ -8,14 +8,16 @@ When DataContext.build_data_docs() is called, there are side effects that may
 include external cloud storage. Here we are running in a GitHub Action, so we
 create a temporary site store for use only within this action. When docs are
 built we only build this temporary site.
-
+"""
 # TODO it is not yet clear if this will surprise users. If users want their
 # TODO  cloud sites updated we could parameterize this behavior in the future.
-"""
+
+
 import os
 import uuid
 
 import great_expectations as ge
+from great_expectations.data_context.store import TupleFilesystemStoreBackend
 
 
 def build_site_name() -> str:
@@ -48,8 +50,14 @@ def main():
 
     print(f"Building docs for site: {action_site_name}")
 
+    validation_store = context.stores["validations_store"]
+    if not isinstance(validation_store.store_backend, TupleFilesystemStoreBackend):
+        # TODO the action will likely need to run entirely in python so an ephemeral
+        #  validation store can be used if desired.
+        print("WARNING an external validation store exists and was likely polluted.")
+
     # Build only the GitHub Actions temporary site
-    context.build_data_docs(site_names=[action_site_name])
+    # context.build_data_docs(site_names=[action_site_name])
     print(f"Site built in directory: {gh_site_dir}")
     # For local debugging, this is handy to verify docs built
     context.open_data_docs(site_name=action_site_name)

--- a/run_checkpoints.sh
+++ b/run_checkpoints.sh
@@ -21,6 +21,6 @@ for c in $INPUT_CHECKPOINTS;do
 done
 
 # Build the ephemeral docs site
-build_gh_action_site.py
+./build_gh_action_site.py
 
 # TODO put the built site somewhere interesting

--- a/run_checkpoints.sh
+++ b/run_checkpoints.sh
@@ -20,4 +20,7 @@ for c in $INPUT_CHECKPOINTS;do
     great_expectations checkpoint run $c
 done
 
+# Build the ephemeral docs site
+build_gh_action_site.py
 
+# TODO put the built site somewhere interesting


### PR DESCRIPTION
@hamelsmu This creates a new data docs site, builds only that site (to prevent cloud side effects) and prints the directory. This should be much cleaner than parsing stdout.

There are a few notes in here about details and future parameterization should a user want side effects (data docs to be built on their cloud stores).

Feel free to merge at will.